### PR TITLE
fix: only register middleware during build to prevent dev server crash

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,10 @@ export default function staticHeaders(): AstroIntegration {
   return {
     name: 'astro-static-headers',
     hooks: {
-      'astro:config:setup': ({ addMiddleware }) => {
-        addMiddleware({ entrypoint: new URL('middleware.js', import.meta.url), order: 'pre' });
+      'astro:config:setup': ({ command, addMiddleware }) => {
+        if (command === 'build') {
+          addMiddleware({ entrypoint: new URL('middleware.js', import.meta.url), order: 'pre' });
+        }
       },
       'astro:config:done': ({ config }) => {
         const adapterName = config.adapter?.name;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Middleware registration now only occurs during the build command, preventing unnecessary registration in other contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->